### PR TITLE
Implement scrollable container with fixed webview

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,16 @@
+# NestedWebViewDemo
+
+一个演示“顶部原生 View 折叠后，将滚动权移交给 WebView”的最小 Android 示例。
+
+- CoordinatorLayout + AppBarLayout 作为父容器
+- 顶部是原生 View（可折叠）
+- 底部是 WebView，初始不滚动，随父容器上移；当 WebView 顶到屏幕顶部且 AppBar 完全折叠后，WebView 开始滚动
+
+打开方式：
+1. 用 Android Studio 打开 `android` 目录
+2. 同步 Gradle 后直接运行 `app`
+
+关键点：
+- `AppBarLayout` 使用 `scroll|exitUntilCollapsed`，优先消费向上滚动以折叠顶部原生区块
+- `WebView` 设置 `app:layout_behavior="@string/appbar_scrolling_view_behavior"`
+- 在 `MainActivity` 中通过 `AppBarLayout.OnOffsetChangedListener` + `WebView.setOnTouchListener` 精细控制事件拦截，实现滚动权在父容器与 WebView 之间的顺畅切换

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,0 +1,34 @@
+apply plugin: 'com.android.application'
+
+android {
+    namespace 'com.example.nestedwebviewdemo'
+    compileSdkVersion 34
+
+    defaultConfig {
+        applicationId 'com.example.nestedwebviewdemo'
+        minSdkVersion 21
+        targetSdkVersion 34
+        versionCode 1
+        versionName "1.0"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+}
+
+dependencies {
+    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'androidx.coordinatorlayout:coordinatorlayout:1.2.0'
+    implementation 'androidx.core:core:1.13.1'
+    implementation 'androidx.webkit:webkit:1.10.0'
+}

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Keep rules for release builds (empty for demo)

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.nestedwebviewdemo">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <application
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:icon="@mipmap/ic_launcher"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.NestedWebViewDemo">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android/app/src/main/java/com/example/nestedwebviewdemo/MainActivity.java
+++ b/android/app/src/main/java/com/example/nestedwebviewdemo/MainActivity.java
@@ -1,0 +1,104 @@
+package com.example.nestedwebviewdemo;
+
+import android.os.Bundle;
+import android.view.MotionEvent;
+import android.view.View;
+import android.webkit.WebSettings;
+import android.webkit.WebView;
+
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+
+import com.google.android.material.appbar.AppBarLayout;
+import androidx.core.view.ViewCompat;
+
+public class MainActivity extends AppCompatActivity {
+
+    private AppBarLayout appBarLayout;
+    private WebView webView;
+    private boolean appBarCollapsed = false;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
+
+        appBarLayout = findViewById(R.id.app_bar);
+        webView = findViewById(R.id.webview);
+
+        configureWebView(webView);
+        setupScrollHandoff();
+        loadDemoContent();
+    }
+
+    private void configureWebView(@NonNull WebView webView) {
+        WebSettings settings = webView.getSettings();
+        settings.setJavaScriptEnabled(true);
+        settings.setDomStorageEnabled(true);
+        settings.setLoadWithOverviewMode(true);
+        settings.setUseWideViewPort(true);
+        webView.setOverScrollMode(View.OVER_SCROLL_NEVER);
+        ViewCompat.setNestedScrollingEnabled(webView, true);
+    }
+
+    private void setupScrollHandoff() {
+        appBarLayout.addOnOffsetChangedListener((appBar, verticalOffset) -> {
+            int total = appBar.getTotalScrollRange();
+            appBarCollapsed = total != 0 && Math.abs(verticalOffset) >= total;
+        });
+
+        webView.setOnTouchListener(new View.OnTouchListener() {
+            int lastY;
+
+            @Override
+            public boolean onTouch(View v, MotionEvent event) {
+                switch (event.getActionMasked()) {
+                    case MotionEvent.ACTION_DOWN:
+                        lastY = (int) event.getY();
+                        // 当 AppBar 未折叠，允许父容器拦截处理（由外层滑动）
+                        v.getParent().requestDisallowInterceptTouchEvent(appBarCollapsed);
+                        break;
+                    case MotionEvent.ACTION_MOVE:
+                        int y = (int) event.getY();
+                        int dy = y - lastY; // 手指下移为正（页面向下滚）
+                        lastY = y;
+
+                        boolean scrollingDown = dy > 0;
+                        boolean canScrollUp = webView.canScrollVertically(-1); // 内容是否可向下滚（即是否已向上滚动过）
+
+                        if (!appBarCollapsed) {
+                            // 顶部未折叠，交给父容器（CoordinatorLayout/AppBarLayout）优先消费
+                            v.getParent().requestDisallowInterceptTouchEvent(false);
+                        } else if (scrollingDown && !canScrollUp) {
+                            // WebView 已回到顶部且向下滑，交给父容器以展开 AppBar
+                            v.getParent().requestDisallowInterceptTouchEvent(false);
+                        } else {
+                            // 其他情况交给 WebView 自己滚动
+                            v.getParent().requestDisallowInterceptTouchEvent(true);
+                        }
+                        break;
+                    case MotionEvent.ACTION_CANCEL:
+                    case MotionEvent.ACTION_UP:
+                        // 结束手势，允许父容器按需拦截
+                        v.getParent().requestDisallowInterceptTouchEvent(false);
+                        break;
+                }
+                // 返回 false 让 WebView 继续接收事件，是否真正滚动由上面的拦截开关决定
+                return false;
+            }
+        });
+    }
+
+    private void loadDemoContent() {
+        // 生成超出一屏的长内容，避免外网依赖
+        StringBuilder html = new StringBuilder();
+        html.append("<html><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"></head><body>");
+        html.append("<h2>下半部分为 WebView，内容较长</h2>");
+        html.append("<p>向上滑动：先折叠上半部分原生视图，WebView 固定在顶部；折叠完毕后开始滚动 WebView 内容。</p>");
+        for (int i = 1; i <= 80; i++) {
+            html.append("<p>段落 ").append(i).append(": 这是示例文本，用于制造长页面效果。滚动联动应在此处生效。</p>");
+        }
+        html.append("</body></html>");
+        webView.loadDataWithBaseURL(null, html.toString(), "text/html", "UTF-8", null);
+    }
+}

--- a/android/app/src/main/java/com/example/nestedwebviewdemo/MainActivity.java
+++ b/android/app/src/main/java/com/example/nestedwebviewdemo/MainActivity.java
@@ -7,9 +7,12 @@ import android.webkit.WebSettings;
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.google.android.material.appbar.AppBarLayout;
+
 public class MainActivity extends AppCompatActivity {
 
     private NestedScrollWebView webView;
+    private AppBarLayout appBarLayout;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -17,7 +20,9 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         webView = findViewById(R.id.webview);
+        appBarLayout = findViewById(R.id.app_bar);
         configureWebView(webView);
+        hookScrollHandoff();
         loadDemoContent();
     }
 
@@ -28,15 +33,24 @@ public class MainActivity extends AppCompatActivity {
         settings.setLoadWithOverviewMode(true);
         settings.setUseWideViewPort(true);
         webView.setOverScrollMode(View.OVER_SCROLL_NEVER);
+        webView.setAllowScroll(false);
+    }
+
+    private void hookScrollHandoff() {
+        appBarLayout.addOnOffsetChangedListener((appBar, verticalOffset) -> {
+            int total = appBar.getTotalScrollRange();
+            boolean collapsed = total != 0 && Math.abs(verticalOffset) >= total;
+            webView.setAllowScroll(collapsed);
+        });
     }
 
     private void loadDemoContent() {
         StringBuilder html = new StringBuilder();
         html.append("<html><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"></head><body>");
         html.append("<h2>下半部分为 WebView，内容较长</h2>");
-        html.append("<p>向上滑动：先由外层折叠原生视图，WebView 吸顶后开始滚动其内容。</p>");
-        for (int i = 1; i <= 80; i++) {
-            html.append("<p>段落 ").append(i).append(": 这是示例文本，用于制造长页面效果。滚动联动应在此处生效。</p>");
+        html.append("<p>开始时 WebView 不滚；当上方原生视图完全滑出（吸顶）后，WebView 才开始滚动内容。</p>");
+        for (int i = 1; i <= 120; i++) {
+            html.append("<p>段落 ").append(i).append(": 长页面内容用于测试联动。</p>");
         }
         html.append("</body></html>");
         webView.loadDataWithBaseURL(null, html.toString(), "text/html", "UTF-8", null);

--- a/android/app/src/main/java/com/example/nestedwebviewdemo/MainActivity.java
+++ b/android/app/src/main/java/com/example/nestedwebviewdemo/MainActivity.java
@@ -1,100 +1,40 @@
 package com.example.nestedwebviewdemo;
 
 import android.os.Bundle;
-import android.view.MotionEvent;
 import android.view.View;
 import android.webkit.WebSettings;
-import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
-import com.google.android.material.appbar.AppBarLayout;
-import androidx.core.view.ViewCompat;
-
 public class MainActivity extends AppCompatActivity {
 
-    private AppBarLayout appBarLayout;
-    private WebView webView;
-    private boolean appBarCollapsed = false;
+    private NestedScrollWebView webView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        appBarLayout = findViewById(R.id.app_bar);
         webView = findViewById(R.id.webview);
-
         configureWebView(webView);
-        setupScrollHandoff();
         loadDemoContent();
     }
 
-    private void configureWebView(@NonNull WebView webView) {
+    private void configureWebView(@NonNull NestedScrollWebView webView) {
         WebSettings settings = webView.getSettings();
         settings.setJavaScriptEnabled(true);
         settings.setDomStorageEnabled(true);
         settings.setLoadWithOverviewMode(true);
         settings.setUseWideViewPort(true);
         webView.setOverScrollMode(View.OVER_SCROLL_NEVER);
-        ViewCompat.setNestedScrollingEnabled(webView, true);
-    }
-
-    private void setupScrollHandoff() {
-        appBarLayout.addOnOffsetChangedListener((appBar, verticalOffset) -> {
-            int total = appBar.getTotalScrollRange();
-            appBarCollapsed = total != 0 && Math.abs(verticalOffset) >= total;
-        });
-
-        webView.setOnTouchListener(new View.OnTouchListener() {
-            int lastY;
-
-            @Override
-            public boolean onTouch(View v, MotionEvent event) {
-                switch (event.getActionMasked()) {
-                    case MotionEvent.ACTION_DOWN:
-                        lastY = (int) event.getY();
-                        // 当 AppBar 未折叠，允许父容器拦截处理（由外层滑动）
-                        v.getParent().requestDisallowInterceptTouchEvent(appBarCollapsed);
-                        break;
-                    case MotionEvent.ACTION_MOVE:
-                        int y = (int) event.getY();
-                        int dy = y - lastY; // 手指下移为正（页面向下滚）
-                        lastY = y;
-
-                        boolean scrollingDown = dy > 0;
-                        boolean canScrollUp = webView.canScrollVertically(-1); // 内容是否可向下滚（即是否已向上滚动过）
-
-                        if (!appBarCollapsed) {
-                            // 顶部未折叠，交给父容器（CoordinatorLayout/AppBarLayout）优先消费
-                            v.getParent().requestDisallowInterceptTouchEvent(false);
-                        } else if (scrollingDown && !canScrollUp) {
-                            // WebView 已回到顶部且向下滑，交给父容器以展开 AppBar
-                            v.getParent().requestDisallowInterceptTouchEvent(false);
-                        } else {
-                            // 其他情况交给 WebView 自己滚动
-                            v.getParent().requestDisallowInterceptTouchEvent(true);
-                        }
-                        break;
-                    case MotionEvent.ACTION_CANCEL:
-                    case MotionEvent.ACTION_UP:
-                        // 结束手势，允许父容器按需拦截
-                        v.getParent().requestDisallowInterceptTouchEvent(false);
-                        break;
-                }
-                // 返回 false 让 WebView 继续接收事件，是否真正滚动由上面的拦截开关决定
-                return false;
-            }
-        });
     }
 
     private void loadDemoContent() {
-        // 生成超出一屏的长内容，避免外网依赖
         StringBuilder html = new StringBuilder();
         html.append("<html><head><meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\"></head><body>");
         html.append("<h2>下半部分为 WebView，内容较长</h2>");
-        html.append("<p>向上滑动：先折叠上半部分原生视图，WebView 固定在顶部；折叠完毕后开始滚动 WebView 内容。</p>");
+        html.append("<p>向上滑动：先由外层折叠原生视图，WebView 吸顶后开始滚动其内容。</p>");
         for (int i = 1; i <= 80; i++) {
             html.append("<p>段落 ").append(i).append(": 这是示例文本，用于制造长页面效果。滚动联动应在此处生效。</p>");
         }

--- a/android/app/src/main/java/com/example/nestedwebviewdemo/NestedScrollWebView.java
+++ b/android/app/src/main/java/com/example/nestedwebviewdemo/NestedScrollWebView.java
@@ -1,0 +1,164 @@
+package com.example.nestedwebviewdemo;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.MotionEvent;
+import android.view.VelocityTracker;
+import android.view.ViewConfiguration;
+import android.webkit.WebView;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.view.NestedScrollingChild2;
+import androidx.core.view.NestedScrollingChildHelper;
+import androidx.core.view.ViewCompat;
+
+public class NestedScrollWebView extends WebView implements NestedScrollingChild2 {
+
+    private final int touchSlop;
+    private final NestedScrollingChildHelper nestedScrollingChildHelper;
+
+    private int lastTouchY;
+    private int nestedOffsetY;
+    private final int[] scrollConsumed = new int[2];
+    private final int[] scrollOffset = new int[2];
+
+    private VelocityTracker velocityTracker;
+
+    public NestedScrollWebView(@NonNull Context context) {
+        this(context, null);
+    }
+
+    public NestedScrollWebView(@NonNull Context context, @Nullable AttributeSet attrs) {
+        this(context, attrs, android.R.attr.webViewStyle);
+    }
+
+    public NestedScrollWebView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        ViewConfiguration configuration = ViewConfiguration.get(context);
+        touchSlop = configuration.getScaledTouchSlop();
+        nestedScrollingChildHelper = new NestedScrollingChildHelper(this);
+        setNestedScrollingEnabled(true);
+        setOverScrollMode(OVER_SCROLL_NEVER);
+    }
+
+    @Override
+    public boolean onTouchEvent(MotionEvent event) {
+        boolean handled;
+        MotionEvent trackedEvent = MotionEvent.obtain(event);
+        final int action = event.getActionMasked();
+
+        if (velocityTracker == null) {
+            velocityTracker = VelocityTracker.obtain();
+        }
+        velocityTracker.addMovement(event);
+
+        if (action == MotionEvent.ACTION_DOWN) {
+            nestedOffsetY = 0;
+        }
+        // Offset event by any nested offset so parent consumes first
+        trackedEvent.offsetLocation(0, nestedOffsetY);
+
+        switch (action) {
+            case MotionEvent.ACTION_DOWN: {
+                lastTouchY = (int) event.getY();
+                startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL, ViewCompat.TYPE_TOUCH);
+                handled = super.onTouchEvent(trackedEvent);
+                break;
+            }
+            case MotionEvent.ACTION_MOVE: {
+                int y = (int) event.getY();
+                int dy = lastTouchY - y; // up is positive
+
+                // 让父容器优先预消费（例如 AppBar 折叠）
+                if (dispatchNestedPreScroll(0, dy, scrollConsumed, scrollOffset, ViewCompat.TYPE_TOUCH)) {
+                    dy -= scrollConsumed[1];
+                    trackedEvent.offsetLocation(0, scrollOffset[1]);
+                    nestedOffsetY += scrollOffset[1];
+                }
+
+                int oldY = getScrollY();
+                handled = super.onTouchEvent(trackedEvent);
+                int scrolledByY = getScrollY() - oldY;
+
+                int unconsumedY = dy - scrolledByY;
+                // 将未消费部分继续交给父容器（例如当 WebView 在顶部或底部时）
+                dispatchNestedScroll(0, scrolledByY, 0, unconsumedY, scrollOffset, ViewCompat.TYPE_TOUCH);
+
+                lastTouchY = y - scrollOffset[1];
+                break;
+            }
+            case MotionEvent.ACTION_UP: {
+                handled = super.onTouchEvent(trackedEvent);
+                stopNestedScroll(ViewCompat.TYPE_TOUCH);
+                if (velocityTracker != null) {
+                    velocityTracker.recycle();
+                    velocityTracker = null;
+                }
+                break;
+            }
+            case MotionEvent.ACTION_CANCEL: {
+                handled = super.onTouchEvent(trackedEvent);
+                stopNestedScroll(ViewCompat.TYPE_TOUCH);
+                if (velocityTracker != null) {
+                    velocityTracker.recycle();
+                    velocityTracker = null;
+                }
+                break;
+            }
+            default:
+                handled = super.onTouchEvent(trackedEvent);
+        }
+
+        trackedEvent.recycle();
+        return handled;
+    }
+
+    // NestedScrollingChild2 implementation
+    @Override
+    public void setNestedScrollingEnabled(boolean enabled) {
+        nestedScrollingChildHelper.setNestedScrollingEnabled(enabled);
+    }
+
+    @Override
+    public boolean isNestedScrollingEnabled() {
+        return nestedScrollingChildHelper.isNestedScrollingEnabled();
+    }
+
+    @Override
+    public boolean startNestedScroll(int axes, int type) {
+        return nestedScrollingChildHelper.startNestedScroll(axes, type);
+    }
+
+    @Override
+    public void stopNestedScroll(int type) {
+        nestedScrollingChildHelper.stopNestedScroll(type);
+    }
+
+    @Override
+    public boolean hasNestedScrollingParent(int type) {
+        return nestedScrollingChildHelper.hasNestedScrollingParent(type);
+    }
+
+    @Override
+    public boolean dispatchNestedPreScroll(int dx, int dy, int[] consumed, int[] offsetInWindow, int type) {
+        return nestedScrollingChildHelper.dispatchNestedPreScroll(dx, dy, consumed, offsetInWindow, type);
+    }
+
+    @Override
+    public void dispatchNestedScroll(int dxConsumed, int dyConsumed, int dxUnconsumed, int dyUnconsumed,
+                                     int[] offsetInWindow, int type) {
+        nestedScrollingChildHelper.dispatchNestedScroll(dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed,
+                offsetInWindow, type);
+    }
+
+    @Override
+    public boolean dispatchNestedPreFling(float velocityX, float velocityY) {
+        return nestedScrollingChildHelper.dispatchNestedPreFling(velocityX, velocityY);
+    }
+
+    @Override
+    public boolean dispatchNestedFling(float velocityX, float velocityY, boolean consumed) {
+        return nestedScrollingChildHelper.dispatchNestedFling(velocityX, velocityY, consumed);
+    }
+}

--- a/android/app/src/main/java/com/example/nestedwebviewdemo/NestedScrollWebView.java
+++ b/android/app/src/main/java/com/example/nestedwebviewdemo/NestedScrollWebView.java
@@ -23,6 +23,9 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
     private final int[] scrollOffset = new int[2];
 
     private VelocityTracker velocityTracker;
+    private int activePointerId = MotionEvent.INVALID_POINTER_ID;
+    private final int maximumFlingVelocity;
+
     private volatile boolean allowScroll = false;
 
     public NestedScrollWebView(@NonNull Context context) {
@@ -38,16 +41,21 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
         nestedScrollingChildHelper = new NestedScrollingChildHelper(this);
         setNestedScrollingEnabled(true);
         setOverScrollMode(OVER_SCROLL_NEVER);
+        ViewConfiguration vc = ViewConfiguration.get(context);
+        maximumFlingVelocity = vc.getScaledMaximumFlingVelocity();
     }
 
     public void setAllowScroll(boolean allow) {
         this.allowScroll = allow;
+        if (!allow) {
+            // 确保内容不会意外保留滚动位置
+            scrollTo(getScrollX(), 0);
+        }
     }
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        boolean handled = true;
-        MotionEvent trackedEvent = MotionEvent.obtain(event);
+        MotionEvent tracked = MotionEvent.obtain(event);
         final int action = event.getActionMasked();
 
         if (velocityTracker == null) {
@@ -57,46 +65,73 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
 
         if (action == MotionEvent.ACTION_DOWN) {
             nestedOffsetY = 0;
+            activePointerId = event.getPointerId(0);
             lastTouchY = (int) event.getY();
             startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL, ViewCompat.TYPE_TOUCH);
-            // 让 WebView 接管手势（以便中途在吸顶瞬间无缝切换到自身滚动）
-            handled = super.onTouchEvent(trackedEvent);
-        } else if (action == MotionEvent.ACTION_MOVE) {
-            int y = (int) event.getY();
-            int dy = lastTouchY - y; // up is positive
+            // 仅建立手势，不在未允许时产生滚动
+            super.onTouchEvent(tracked);
+            tracked.recycle();
+            return true;
+        }
+
+        if (action == MotionEvent.ACTION_MOVE) {
+            int index = event.findPointerIndex(activePointerId);
+            if (index < 0) index = 0;
+            int y = (int) event.getY(index);
+            int dy = lastTouchY - y; // up positive
 
             // 父容器预消费（用于折叠/展开 AppBar）
             if (dispatchNestedPreScroll(0, dy, scrollConsumed, scrollOffset, ViewCompat.TYPE_TOUCH)) {
                 dy -= scrollConsumed[1];
-                trackedEvent.offsetLocation(0, scrollOffset[1]);
+                tracked.offsetLocation(0, scrollOffset[1]);
                 nestedOffsetY += scrollOffset[1];
             }
 
             int scrolledByY = 0;
             if (allowScroll) {
-                int oldY = getScrollY();
-                super.onTouchEvent(trackedEvent);
-                scrolledByY = getScrollY() - oldY;
+                int before = getScrollY();
+                super.onTouchEvent(tracked);
+                scrolledByY = getScrollY() - before;
             }
 
             int unconsumedY = dy - scrolledByY;
-            // 将未消费部分交还父容器
             dispatchNestedScroll(0, scrolledByY, 0, unconsumedY, scrollOffset, ViewCompat.TYPE_TOUCH);
 
             lastTouchY = y - scrollOffset[1];
-        } else if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
-            super.onTouchEvent(trackedEvent);
+            tracked.recycle();
+            return true;
+        }
+
+        if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+            // 处理 fling：未允许滚动时，优先交给父容器
+            velocityTracker.computeCurrentVelocity(1000, maximumFlingVelocity);
+            float vY = velocityTracker.getYVelocity(activePointerId);
+            float velocityY = -vY; // up positive
+
+            if (!allowScroll) {
+                boolean parentConsumed = dispatchNestedPreFling(0, velocityY);
+                dispatchNestedFling(0, velocityY, parentConsumed);
+                // 不把 fling 交给 WebView
+            } else {
+                // 允许滚动时，先询问父容器预消费，再交给 WebView 自己处理
+                dispatchNestedPreFling(0, velocityY);
+                super.onTouchEvent(tracked);
+                dispatchNestedFling(0, velocityY, true);
+            }
+
             stopNestedScroll(ViewCompat.TYPE_TOUCH);
+            activePointerId = MotionEvent.INVALID_POINTER_ID;
             if (velocityTracker != null) {
                 velocityTracker.recycle();
                 velocityTracker = null;
             }
-        } else {
-            handled = super.onTouchEvent(trackedEvent);
+            tracked.recycle();
+            return true;
         }
 
-        trackedEvent.recycle();
-        return handled;
+        boolean result = super.onTouchEvent(tracked);
+        tracked.recycle();
+        return result;
     }
 
     // NestedScrollingChild2 implementation

--- a/android/app/src/main/java/com/example/nestedwebviewdemo/NestedScrollWebView.java
+++ b/android/app/src/main/java/com/example/nestedwebviewdemo/NestedScrollWebView.java
@@ -15,7 +15,6 @@ import androidx.core.view.ViewCompat;
 
 public class NestedScrollWebView extends WebView implements NestedScrollingChild2 {
 
-    private final int touchSlop;
     private final NestedScrollingChildHelper nestedScrollingChildHelper;
 
     private int lastTouchY;
@@ -24,6 +23,7 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
     private final int[] scrollOffset = new int[2];
 
     private VelocityTracker velocityTracker;
+    private volatile boolean allowScroll = false;
 
     public NestedScrollWebView(@NonNull Context context) {
         this(context, null);
@@ -35,16 +35,18 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
 
     public NestedScrollWebView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        ViewConfiguration configuration = ViewConfiguration.get(context);
-        touchSlop = configuration.getScaledTouchSlop();
         nestedScrollingChildHelper = new NestedScrollingChildHelper(this);
         setNestedScrollingEnabled(true);
         setOverScrollMode(OVER_SCROLL_NEVER);
     }
 
+    public void setAllowScroll(boolean allow) {
+        this.allowScroll = allow;
+    }
+
     @Override
     public boolean onTouchEvent(MotionEvent event) {
-        boolean handled;
+        boolean handled = true;
         MotionEvent trackedEvent = MotionEvent.obtain(event);
         final int action = event.getActionMasked();
 
@@ -55,59 +57,42 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
 
         if (action == MotionEvent.ACTION_DOWN) {
             nestedOffsetY = 0;
-        }
-        // Offset event by any nested offset so parent consumes first
-        trackedEvent.offsetLocation(0, nestedOffsetY);
+            lastTouchY = (int) event.getY();
+            startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL, ViewCompat.TYPE_TOUCH);
+            // 让 WebView 接管手势（以便中途在吸顶瞬间无缝切换到自身滚动）
+            handled = super.onTouchEvent(trackedEvent);
+        } else if (action == MotionEvent.ACTION_MOVE) {
+            int y = (int) event.getY();
+            int dy = lastTouchY - y; // up is positive
 
-        switch (action) {
-            case MotionEvent.ACTION_DOWN: {
-                lastTouchY = (int) event.getY();
-                startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL, ViewCompat.TYPE_TOUCH);
-                handled = super.onTouchEvent(trackedEvent);
-                break;
+            // 父容器预消费（用于折叠/展开 AppBar）
+            if (dispatchNestedPreScroll(0, dy, scrollConsumed, scrollOffset, ViewCompat.TYPE_TOUCH)) {
+                dy -= scrollConsumed[1];
+                trackedEvent.offsetLocation(0, scrollOffset[1]);
+                nestedOffsetY += scrollOffset[1];
             }
-            case MotionEvent.ACTION_MOVE: {
-                int y = (int) event.getY();
-                int dy = lastTouchY - y; // up is positive
 
-                // 让父容器优先预消费（例如 AppBar 折叠）
-                if (dispatchNestedPreScroll(0, dy, scrollConsumed, scrollOffset, ViewCompat.TYPE_TOUCH)) {
-                    dy -= scrollConsumed[1];
-                    trackedEvent.offsetLocation(0, scrollOffset[1]);
-                    nestedOffsetY += scrollOffset[1];
-                }
-
+            int scrolledByY = 0;
+            if (allowScroll) {
                 int oldY = getScrollY();
-                handled = super.onTouchEvent(trackedEvent);
-                int scrolledByY = getScrollY() - oldY;
+                super.onTouchEvent(trackedEvent);
+                scrolledByY = getScrollY() - oldY;
+            }
 
-                int unconsumedY = dy - scrolledByY;
-                // 将未消费部分继续交给父容器（例如当 WebView 在顶部或底部时）
-                dispatchNestedScroll(0, scrolledByY, 0, unconsumedY, scrollOffset, ViewCompat.TYPE_TOUCH);
+            int unconsumedY = dy - scrolledByY;
+            // 将未消费部分交还父容器
+            dispatchNestedScroll(0, scrolledByY, 0, unconsumedY, scrollOffset, ViewCompat.TYPE_TOUCH);
 
-                lastTouchY = y - scrollOffset[1];
-                break;
+            lastTouchY = y - scrollOffset[1];
+        } else if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
+            super.onTouchEvent(trackedEvent);
+            stopNestedScroll(ViewCompat.TYPE_TOUCH);
+            if (velocityTracker != null) {
+                velocityTracker.recycle();
+                velocityTracker = null;
             }
-            case MotionEvent.ACTION_UP: {
-                handled = super.onTouchEvent(trackedEvent);
-                stopNestedScroll(ViewCompat.TYPE_TOUCH);
-                if (velocityTracker != null) {
-                    velocityTracker.recycle();
-                    velocityTracker = null;
-                }
-                break;
-            }
-            case MotionEvent.ACTION_CANCEL: {
-                handled = super.onTouchEvent(trackedEvent);
-                stopNestedScroll(ViewCompat.TYPE_TOUCH);
-                if (velocityTracker != null) {
-                    velocityTracker.recycle();
-                    velocityTracker = null;
-                }
-                break;
-            }
-            default:
-                handled = super.onTouchEvent(trackedEvent);
+        } else {
+            handled = super.onTouchEvent(trackedEvent);
         }
 
         trackedEvent.recycle();

--- a/android/app/src/main/java/com/example/nestedwebviewdemo/NestedScrollWebView.java
+++ b/android/app/src/main/java/com/example/nestedwebviewdemo/NestedScrollWebView.java
@@ -5,6 +5,7 @@ import android.util.AttributeSet;
 import android.view.MotionEvent;
 import android.view.VelocityTracker;
 import android.view.ViewConfiguration;
+import android.view.ViewParent;
 import android.webkit.WebView;
 
 import androidx.annotation.NonNull;
@@ -25,6 +26,8 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
     private VelocityTracker velocityTracker;
     private int activePointerId = MotionEvent.INVALID_POINTER_ID;
     private final int maximumFlingVelocity;
+    private final int touchSlop;
+    private boolean isDragging = false;
 
     private volatile boolean allowScroll = false;
 
@@ -43,12 +46,12 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
         setOverScrollMode(OVER_SCROLL_NEVER);
         ViewConfiguration vc = ViewConfiguration.get(context);
         maximumFlingVelocity = vc.getScaledMaximumFlingVelocity();
+        touchSlop = vc.getScaledTouchSlop();
     }
 
     public void setAllowScroll(boolean allow) {
         this.allowScroll = allow;
         if (!allow) {
-            // 确保内容不会意外保留滚动位置
             scrollTo(getScrollX(), 0);
         }
     }
@@ -67,8 +70,8 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
             nestedOffsetY = 0;
             activePointerId = event.getPointerId(0);
             lastTouchY = (int) event.getY();
+            isDragging = false;
             startNestedScroll(ViewCompat.SCROLL_AXIS_VERTICAL, ViewCompat.TYPE_TOUCH);
-            // 仅建立手势，不在未允许时产生滚动
             super.onTouchEvent(tracked);
             tracked.recycle();
             return true;
@@ -78,13 +81,31 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
             int index = event.findPointerIndex(activePointerId);
             if (index < 0) index = 0;
             int y = (int) event.getY(index);
-            int dy = lastTouchY - y; // up positive
+            int dyRaw = lastTouchY - y; // up positive
 
-            // 父容器预消费（用于折叠/展开 AppBar）
+            if (!isDragging && Math.abs(dyRaw) > touchSlop) {
+                isDragging = true;
+            }
+            if (!isDragging) {
+                tracked.recycle();
+                return true;
+            }
+
+            int dy = dyRaw;
+
             if (dispatchNestedPreScroll(0, dy, scrollConsumed, scrollOffset, ViewCompat.TYPE_TOUCH)) {
                 dy -= scrollConsumed[1];
                 tracked.offsetLocation(0, scrollOffset[1]);
                 nestedOffsetY += scrollOffset[1];
+            }
+
+            // 当允许 WebView 滚动时，避免父容器抢夺事件；反之允许父容器拦截
+            ViewParent parent = getParent();
+            if (parent != null) {
+                boolean atTop = !canScrollVertically(-1);
+                boolean scrollingDown = dy < 0; // finger moves down, content tries to scroll down
+                boolean disallow = allowScroll && !(scrollingDown && atTop);
+                parent.requestDisallowInterceptTouchEvent(disallow);
             }
 
             int scrolledByY = 0;
@@ -103,7 +124,6 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
         }
 
         if (action == MotionEvent.ACTION_UP || action == MotionEvent.ACTION_CANCEL) {
-            // 处理 fling：未允许滚动时，优先交给父容器
             velocityTracker.computeCurrentVelocity(1000, maximumFlingVelocity);
             float vY = velocityTracker.getYVelocity(activePointerId);
             float velocityY = -vY; // up positive
@@ -111,9 +131,7 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
             if (!allowScroll) {
                 boolean parentConsumed = dispatchNestedPreFling(0, velocityY);
                 dispatchNestedFling(0, velocityY, parentConsumed);
-                // 不把 fling 交给 WebView
             } else {
-                // 允许滚动时，先询问父容器预消费，再交给 WebView 自己处理
                 dispatchNestedPreFling(0, velocityY);
                 super.onTouchEvent(tracked);
                 dispatchNestedFling(0, velocityY, true);
@@ -121,6 +139,7 @@ public class NestedScrollWebView extends WebView implements NestedScrollingChild
 
             stopNestedScroll(ViewCompat.TYPE_TOUCH);
             activePointerId = MotionEvent.INVALID_POINTER_ID;
+            isDragging = false;
             if (velocityTracker != null) {
                 velocityTracker.recycle();
                 velocityTracker = null;

--- a/android/app/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/android/app/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <group android:scaleX="0.7" android:scaleY="0.7" android:translateX="16" android:translateY="16">
+        <path
+            android:fillColor="#FFFFFF"
+            android:pathData="M54,10c24.3,0 44,19.7 44,44 0,24.3 -19.7,44 -44,44 -24.3,0 -44,-19.7 -44,-44 0,-24.3 19.7,-44 44,-44z"/>
+        <path
+            android:fillColor="#6750A4"
+            android:pathData="M54,26L38,38l16,12 16,-12zM38,46v18l16,12 16,-12V46L54,58z"/>
+    </group>
+</vector>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/app_bar"
+        android:layout_width="match_parent"
+        android:layout_height="260dp"
+        android:fitsSystemWindows="true"
+        android:background="@color/headerBackground">
+
+        <LinearLayout
+            android:id="@+id/native_header"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:orientation="vertical"
+            app:layout_scrollFlags="scroll|exitUntilCollapsed"
+            android:gravity="center">
+
+            <TextView
+                android:id="@+id/title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="原生 Header"
+                android:textSize="24sp"
+                android:textColor="@android:color/white" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="上半部分是原生 View，可折叠"
+                android:textColor="@android:color/white" />
+        </LinearLayout>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <WebView
+        android:id="@+id/webview"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -17,7 +17,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:orientation="vertical"
-            app:layout_scrollFlags="scroll|exitUntilCollapsed"
+            app:layout_scrollFlags="scroll"
             android:gravity="center">
 
             <TextView

--- a/android/app/src/main/res/layout/activity_main.xml
+++ b/android/app/src/main/res/layout/activity_main.xml
@@ -37,7 +37,7 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <WebView
+    <com.example.nestedwebviewdemo.NestedScrollWebView
         android:id="@+id/webview"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/android/app/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/ic_launcher_background" />
+    <foreground android:drawable="@drawable/ic_launcher_foreground" />
+</adaptive-icon>

--- a/android/app/src/main/res/values/colors.xml
+++ b/android/app/src/main/res/values/colors.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="purple_500">#6750A4</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="headerBackground">#3F51B5</color>
+</resources>

--- a/android/app/src/main/res/values/ic_launcher_background.xml
+++ b/android/app/src/main/res/values/ic_launcher_background.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <color name="ic_launcher_background">#6750A4</color>
+</resources>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">NestedWebViewDemo</string>
+</resources>

--- a/android/app/src/main/res/values/themes.xml
+++ b/android/app/src/main/res/values/themes.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.NestedWebViewDemo" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/purple_500</item>
+        <item name="colorPrimaryVariant">@color/purple_700</item>
+        <item name="colorSecondary">@color/teal_200</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
+    </style>
+</resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,0 +1,20 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.4.2'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "NestedWebViewDemo"
+include ':app'


### PR DESCRIPTION
Implement nested scrolling for an Android app with a collapsible native header and a WebView.

This allows the native header to collapse first, then transfers scroll control to the WebView, and reverts control back to the parent when scrolling up from the top of the WebView, fulfilling the user's specific scroll behavior requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f3fa8d1-cda7-4eec-a631-b376d4837ede">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f3fa8d1-cda7-4eec-a631-b376d4837ede">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

